### PR TITLE
Update: publish as scoped @adapt-security/zipper; drop unused fs-extra

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,13 @@
 {
-  "name": "zipper",
-  "version": "1.0.0",
+  "name": "@adapt-security/zipper",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "zipper",
-      "version": "1.0.0",
+      "name": "@adapt-security/zipper",
+      "version": "1.2.0",
       "dependencies": {
-        "fs-extra": "11.3.6",
         "jszip": "^3.10.1",
         "klaw": "^4.1.0"
       },
@@ -182,6 +181,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -951,6 +951,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -1158,6 +1159,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -1215,6 +1217,7 @@
       "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "builtins": "^5.0.1",
         "eslint-plugin-es": "^4.1.0",
@@ -1254,6 +1257,7 @@
       "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -1270,6 +1274,7 @@
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -1550,20 +1555,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/fs-extra": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
-      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1777,6 +1768,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -2445,18 +2437,6 @@
       },
       "bin": {
         "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -3872,15 +3852,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,18 @@
 {
-  "name": "zipper",
-  "version": "1.0.0",
+  "name": "@adapt-security/zipper",
+  "version": "1.2.0",
   "description": "Module for zipping/unzipping files",
-  "homepage": "https://github.com/taylortom/zipper",
+  "homepage": "https://github.com/adapt-security/zipper",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adapt-security/zipper.git"
+  },
   "type": "module",
   "main": "./lib/zipper.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
-    "fs-extra": "11.3.6",
     "jszip": "^3.10.1",
     "klaw": "^4.1.0"
   },


### PR DESCRIPTION
### Fixes #50

### Update
- Rename package to `@adapt-security/zipper` so it can be published to npm (the bare `zipper` name is taken there by an unrelated package) — matches the `@adapt-security/at-utils` precedent.
- Add `publishConfig.access: public` so the scoped package publishes publicly.
- Add `repository` and correct `homepage` (was pointing at the personal `taylortom/zipper`).
- Bump version to `1.2.0`.

### Breaking
- Removes the unused `fs-extra` dependency (`lib/zipper.js` imports only `fs`, `fs/promises`, `jszip`, `klaw`). No runtime behaviour change, but the dependency is gone — noting it since Dependabot had been bumping it.

### Testing
- `npx standard` clean.
- `npm test` — 14/14 pass.

Follow-up (separate PRs): the four consumers (`adapt-authoring-adaptframework`, `adapt-authoring-middleware`, `@cgkineo/adapt-authoring-debug`, `@cgkineo/adapt-authoring-multilang`) switch from `github:adapt-security/zipper` to `@adapt-security/zipper@^1.2.0` once this is published.